### PR TITLE
New CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,37 @@
+---
+name: Merges
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Maven Options
+        run:
+          echo "::set-env name=MAVEN_OPTS::-Dmaven.repo.local=$HOME/.m2/repository"
+      - name: Set up Java 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build and Run Tests
+        run: mvn $MAVEN_CLI_OPTS install
+      - name: Archive SNAPSHOTs
+        uses: actions/upload-artifact@v1
+        with:
+          name: snapshot
+          path: target

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,33 @@
+---
+name: Pull Requests
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Maven Options
+        run:
+          echo "::set-env name=MAVEN_OPTS::-Dmaven.repo.local=$HOME/.m2/repository"
+      - name: Set up Java 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build and Run Tests
+        run: mvn $MAVEN_CLI_OPTS install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+---
+name: Releases
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    tags:
+      - '[0-9]*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Strip SNAPSHOT Version
+        run: |
+          mvn $MAVEN_CLI_OPTS \
+            versions:set versions:update-child-modules versions:commit \
+            -DnewVersion=${VERSION/refs\/tags\/} \
+            -DgenerateBackupPoms=false
+        env:
+          VERSION: ${{ github.ref }}
+      - name: Publish GitHub Packages
+        run: |
+          mvn $MAVEN_CLI_OPTS \
+            deploy \
+            -D altDeploymentRepository=release::default::${MAVEN_RELEASE_REPO_URL}
+        env:
+          MAVEN_RELEASE_REPO_USER: ${{ github.actor }}
+          MAVEN_RELEASE_REPO_PASS: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_RELEASE_REPO_URL: https://maven.pkg.github.com/${{ github.repository }}

--- a/.m2/settings.xml
+++ b/.m2/settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <servers>
+    <server>
+      <id>release</id>
+      <username>${env.MAVEN_RELEASE_REPO_USER}</username>
+      <password>${env.MAVEN_RELEASE_REPO_PASS}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
Add new CI please!
# CI/CD on github-actions

This pull request adds The Linux Foundation java
toolchain for CI/CD workflows on github-actions.

## Toolchain

The CI/CD workflows for this repository are triggered by the following:

* Pull Requests: Any pull request created will have 'maven install' run
  to build, test, and verify that the project can be installed to a
  local repository.
* Merges: The same workflow for Pull Requests is run but instead of
  installing to a local repository the build is saved as an artifact to GitHub.
* GitHub Releases: At any point the project can be packaged and released by
  creating a GitHub Release. This creates a maven artifact versioned to
  the specified tag of the release and upload it to github-packages.


## Java Environment Variables

The following variables are available to workflows:
- `$MAVEN_RELEASE_REPO_URL`
   URL of the release repository
- `$MAVEN_RELEASE_REPO_USER`
   Username for the release repository
- `$MAVEN_RELEASE_REPO_PASS`
   Password for the release repository

## Updating this Pull Request

If these workflows don't match the needs for your project feel free to
[modify](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally) them to meet your needs.

Signed-off-by: ITX CI \<itx@linuxfoundation.org\>
on-behalf-of: @linuxfoundation-it \<itx@linuxfoundation.org\>